### PR TITLE
fix README for yarn install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install --save @weco/next--plugin-transpile-modules
 or
 
 ```
-yarn add @weco/next--plugin-transpile-modules
+yarn add @weco/next-plugin-transpile-modules
 ```
 
 ## Usage


### PR DESCRIPTION
There was an extra dash in the module name.  Copy and pasting that command didn't work with it in there.